### PR TITLE
chore: extend org Renovate preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // Inherit the org-wide Renovate preset. Add per-repo overrides below
+  // only if this repo needs to deviate from the shared defaults.
+  extends: ["local>seventwo-studio/.github"],
+}


### PR DESCRIPTION
Inherit cooldown, pinning, and stack-aware groups from `local>seventwo-studio/.github`. The preset centralizes 7-day `minimumReleaseAge` with `internalChecksFilter: "strict"`, `:pinAllExceptPeerDependencies`, weekly `lockFileMaintenance`, and grouping for tooling, react, vite, tanstack, astro, cloudflare, hono, drizzle, better-auth, ui, expo + a minor/patch catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)